### PR TITLE
test: add foo alias

### DIFF
--- a/.config/zsh/aliases.zsh
+++ b/.config/zsh/aliases.zsh
@@ -65,6 +65,7 @@ alias pr='$BASH_SCRIPTS_PATH/pr.sh'
 # create a pr with github and use claude to set the description and title of the pr
 alias prd='gh pr create --fill --draft && printf "\nsetting pr title and description with claude...\n\n" && claude "/pr-description-and-title" --print'
 alias prchecks='$BASH_SCRIPTS_PATH/watch-github-pr-ci-status.sh'
+alias foo='foo'
 
 ##########
 # PYTHON #


### PR DESCRIPTION
## Summary
Adds a test alias `foo` to the zsh aliases configuration.

## Changes
- Add `foo='foo'` alias to `.config/zsh/aliases.zsh`